### PR TITLE
requirements: Accept python-dateutil<2.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     download_url='%s/%s/archive/%s.tar.gz' % (github_url, package_name, __version__, ),
     keywords=['codicefiscale', 'codice', 'fiscale', 'cf', 'fiscal code', ],
     install_requires=[
-        'python-dateutil >= 2.6.0, < 2.8.0',
+        'python-dateutil >= 2.6.0, < 2.9.0',
         'python-slugify >= 1.2.0, < 1.3.0',
     ],
     classifiers=[


### PR DESCRIPTION
The current version of `python-codicefiscale` requires version <2.8 of `python-dateutil`. A version 2.8.0 has been released a few days ago and tests seem to pass with that version (and the changelog of `python-dateutil` 2.8.0 seems reasonable). Do you think that we could update the requirement?